### PR TITLE
Optical-rotation and snapshot/radius averaging

### DIFF
--- a/SoAPy/analysis.py
+++ b/SoAPy/analysis.py
@@ -187,6 +187,144 @@ def normal_mode_reordering(dir_frequencies, dir_intensities, sample_index, refer
     return slope_sign
 
 
+def opt_rot_averaging(dir_frequencies, dir_intensities, dir_parameters, dir_list, radius, averaging):
+    #Beta version of the running average analysis
+    #Initialize running sums for each test frequency
+    ints_633 = 0.0
+    ints_589 = 0.0
+    ints_436 = 0.0
+    ints_355 = 0.0
+
+    #Tracking the total number of negative signs in rotations
+    #Doing this to test the idea of stricted conformation sign bias
+    neg_633 = 0
+    neg_589 = 0
+    neg_436 = 0
+    neg_355 = 0
+    
+    #Lists to store the averages
+    avg_633_list = []
+    avg_589_list = []
+    avg_436_list = []
+    avg_355_list = []
+
+    #radius is a function arg that tells the function if we are investigating a changing radius
+    if radius == True:
+        for b in range(len(dir_list)):
+            ints_633 = 0.0
+            ints_589 = 0.0
+            ints_436 = 0.0
+            ints_355 = 0.0
+            chopper = 4*int(dir_parameters[b][5])
+            #The chopper splits the data in dir_frequencies and dir_intensities by radius
+            #This is done by calculating the number of entries that are associated with each radius and sampling them seperately
+            for a in range(0, chopper):
+                #Logic gates to split up the intensities to totals for their corresponding frequency
+                if dir_frequencies[b][a] == 633.0:
+                    ints_633 += dir_intensities[b][a]
+                    #The number of negative signs per frequency is tracked to show if a test/range of tests has a tendency to favor one sign
+                    if dir_intensities[b][a] < 0.0:
+                        neg_633 += 1
+                elif dir_frequencies[b][a] == 589.0:
+                    ints_589 += dir_intensities[b][a]
+                    if dir_intensities[b][a] < 0.0:
+                        neg_589 += 1
+                elif dir_frequencies[b][a] == 436.0:
+                    ints_436 += dir_intensities[b][a]
+                    if dir_intensities[b][a] < 0.0:
+                        neg_436 += 1
+                elif dir_frequencies[b][a] == 355.0:
+                    ints_355 += dir_intensities[b][a]
+                    if dir_intensities[b][a] < 0.0:
+                        neg_355 += 1
+                    
+            #Finding total number of snaps
+            tot_snaps = int(dir_parameters[b][5])
+            #Calculating the average intensity for each freq
+            #Checks the averaging argument, should only be set to True if custom_collect_data is also set to True
+            #If the averaging argument is true then we are dividing by the molar mass of one atom in the system
+            #THE SYSTEM IS WATER ONLY AT THIS TIME
+            if averaging == True:
+                avg_633 = ints_633/(tot_snaps*18.02)
+                avg_589 = ints_589/(tot_snaps*18.02)
+                avg_436 = ints_436/(tot_snaps*18.02)
+                avg_355 = ints_355/(tot_snaps*18.02)
+            
+            elif averaging == False:
+                avg_633 = ints_633/(tot_snaps)
+                avg_589 = ints_589/(tot_snaps)
+                avg_436 = ints_436/(tot_snaps)
+                avg_355 = ints_355/(tot_snaps)
+
+            #Assembling all the averages in a list
+            avg_633_list.append(avg_633)
+            avg_589_list.append(avg_589)
+            avg_436_list.append(avg_436)
+            avg_355_list.append(avg_355)
+            
+            #Print statements to inspect data if needed
+            #print(len(avg_355_list))
+            #print(ints_633, ints_589, ints_436, ints_355)
+            #print(avg_355_list)
+                
+        
+    
+    elif radius == False:    
+        #Pulling the intensities that correspond to each individual frequency tested
+        #This loop uses dir_frequecies because we are assembling a UNIQUE dir_frequencies for EACH time we run the collect_data function
+        #####
+        #This ONLY works properly when inside of a loop within the script
+        #####
+        for a in range(len(dir_frequencies[0])):
+            #Logic gates to split up the intensities to totals for their corresponding frequency
+            if dir_frequencies[b][a] == 633.0:
+                ints_633 += dir_intensities[b][a]
+                #The number of negative signs per frequency is tracked to show if a test/range of tests has a tendency to favor one sign
+                if dir_intensities[0][a] < 0.0:
+                    neg_633 += 1
+            elif dir_frequencies[0][a] == 589.0:
+                ints_589 += dir_intensities[0][a]
+                if dir_intensities[0][a] < 0.0:
+                    neg_589 += 1
+            elif dir_frequencies[0][a] == 436.0:
+                ints_436 += dir_intensities[0][a]
+                if dir_intensities[0][a] < 0.0:
+                    neg_436 += 1
+            elif dir_frequencies[0][a] == 355.0:
+                ints_355 += dir_intensities[0][a]
+                if dir_intensities[0][a] < 0.0:
+                    neg_355 += 1
+                
+        #Finding total number of snaps
+        tot_snaps = len(dir_frequencies[0])/4
+        
+        #Calculating the average intensity for each freq
+        #Checks the averaging argument, should only be set to True if custom_collect_data is also set to True
+        if averaging == True:
+            avg_633 = ints_633/(tot_snaps*18.02)
+            avg_589 = ints_589/(tot_snaps*18.02)
+            avg_436 = ints_436/(tot_snaps*18.02)
+            avg_355 = ints_355/(tot_snaps*18.02)
+        
+        elif averaging == False:
+            avg_633 = ints_633/(tot_snaps)
+            avg_589 = ints_589/(tot_snaps)
+            avg_436 = ints_436/(tot_snaps)
+            avg_355 = ints_355/(tot_snaps)
+
+        #Assembling all the averages in a list
+        avg_633_list.append(avg_633)
+        avg_589_list.append(avg_589)
+        avg_436_list.append(avg_436)
+        avg_355_list.append(avg_355)
+                
+        #avg_list = [avg_633, avg_589, avg_436, avg_355]
+        #print(avg_list)
+
+    #Printing the number of negative signs for each test
+    print("Number of negative signs: 633nm = ", neg_633, " 589nm = ", neg_589, " 436nm = ", neg_436, " 355nm = ", neg_355)
+
+    return avg_633_list, avg_589_list, avg_436_list, avg_355_list
 
 
 

--- a/SoAPy/analysis.py
+++ b/SoAPy/analysis.py
@@ -186,145 +186,29 @@ def normal_mode_reordering(dir_frequencies, dir_intensities, sample_index, refer
 
     return slope_sign
 
-
-def opt_rot_averaging(dir_frequencies, dir_intensities, dir_parameters, dir_list, radius, averaging):
-    #Beta version of the running average analysis
-    #Initialize running sums for each test frequency
-    ints_633 = 0.0
-    ints_589 = 0.0
-    ints_436 = 0.0
-    ints_355 = 0.0
-
-    #Tracking the total number of negative signs in rotations
-    #Doing this to test the idea of stricted conformation sign bias
-    neg_633 = 0
-    neg_589 = 0
-    neg_436 = 0
-    neg_355 = 0
+def opt_rot_averaging(dir_intensities, dir_parameters, dir_list, molecule_MM):
+    #Building loop structure of the RADIUS averaging
+    opt_rot_averages = []
+    for a in range(len(dir_list)):
+        averages = [0]*len(dir_parameters[a][6])
+        #print(averages)
+        b = 0
+        d = len(dir_parameters[a][5])
+        while b < int(dir_parameters[a][5]):
+            for c in range(len(dir_parameters[a][6])):
+                if molecule_MM != 0.0:
+                    averages[c] += float(dir_intensities[a][(d*b)+c])/(float(dir_parameters[a][5])*molecule_MM)
+                elif molecule_MM == 0.0:
+                    averages[c] += float(dir_intensities[a][(d*b)+c])/float(dir_parameters[a][5])
+                print(averages)
+                print(b)
+            b += 1
+        
+        opt_rot_averages.extend(averages)
     
-    #Lists to store the averages
-    avg_633_list = []
-    avg_589_list = []
-    avg_436_list = []
-    avg_355_list = []
+    return opt_rot_averages
 
-    #radius is a function arg that tells the function if we are investigating a changing radius
-    if radius == True:
-        for b in range(len(dir_list)):
-            ints_633 = 0.0
-            ints_589 = 0.0
-            ints_436 = 0.0
-            ints_355 = 0.0
-            chopper = 4*int(dir_parameters[b][5])
-            #The chopper splits the data in dir_frequencies and dir_intensities by radius
-            #This is done by calculating the number of entries that are associated with each radius and sampling them seperately
-            for a in range(0, chopper):
-                #Logic gates to split up the intensities to totals for their corresponding frequency
-                if dir_frequencies[b][a] == 633.0:
-                    ints_633 += dir_intensities[b][a]
-                    #The number of negative signs per frequency is tracked to show if a test/range of tests has a tendency to favor one sign
-                    if dir_intensities[b][a] < 0.0:
-                        neg_633 += 1
-                elif dir_frequencies[b][a] == 589.0:
-                    ints_589 += dir_intensities[b][a]
-                    if dir_intensities[b][a] < 0.0:
-                        neg_589 += 1
-                elif dir_frequencies[b][a] == 436.0:
-                    ints_436 += dir_intensities[b][a]
-                    if dir_intensities[b][a] < 0.0:
-                        neg_436 += 1
-                elif dir_frequencies[b][a] == 355.0:
-                    ints_355 += dir_intensities[b][a]
-                    if dir_intensities[b][a] < 0.0:
-                        neg_355 += 1
-                    
-            #Finding total number of snaps
-            tot_snaps = int(dir_parameters[b][5])
-            #Calculating the average intensity for each freq
-            #Checks the averaging argument, should only be set to True if custom_collect_data is also set to True
-            #If the averaging argument is true then we are dividing by the molar mass of one atom in the system
-            #THE SYSTEM IS WATER ONLY AT THIS TIME
-            if averaging == True:
-                avg_633 = ints_633/(tot_snaps*18.02)
-                avg_589 = ints_589/(tot_snaps*18.02)
-                avg_436 = ints_436/(tot_snaps*18.02)
-                avg_355 = ints_355/(tot_snaps*18.02)
-            
-            elif averaging == False:
-                avg_633 = ints_633/(tot_snaps)
-                avg_589 = ints_589/(tot_snaps)
-                avg_436 = ints_436/(tot_snaps)
-                avg_355 = ints_355/(tot_snaps)
 
-            #Assembling all the averages in a list
-            avg_633_list.append(avg_633)
-            avg_589_list.append(avg_589)
-            avg_436_list.append(avg_436)
-            avg_355_list.append(avg_355)
-            
-            #Print statements to inspect data if needed
-            #print(len(avg_355_list))
-            #print(ints_633, ints_589, ints_436, ints_355)
-            #print(avg_355_list)
-                
-        
-    
-    elif radius == False:    
-        #Pulling the intensities that correspond to each individual frequency tested
-        #This loop uses dir_frequecies because we are assembling a UNIQUE dir_frequencies for EACH time we run the collect_data function
-        #####
-        #This ONLY works properly when inside of a loop within the script
-        #####
-        for a in range(len(dir_frequencies[0])):
-            #Logic gates to split up the intensities to totals for their corresponding frequency
-            if dir_frequencies[b][a] == 633.0:
-                ints_633 += dir_intensities[b][a]
-                #The number of negative signs per frequency is tracked to show if a test/range of tests has a tendency to favor one sign
-                if dir_intensities[0][a] < 0.0:
-                    neg_633 += 1
-            elif dir_frequencies[0][a] == 589.0:
-                ints_589 += dir_intensities[0][a]
-                if dir_intensities[0][a] < 0.0:
-                    neg_589 += 1
-            elif dir_frequencies[0][a] == 436.0:
-                ints_436 += dir_intensities[0][a]
-                if dir_intensities[0][a] < 0.0:
-                    neg_436 += 1
-            elif dir_frequencies[0][a] == 355.0:
-                ints_355 += dir_intensities[0][a]
-                if dir_intensities[0][a] < 0.0:
-                    neg_355 += 1
-                
-        #Finding total number of snaps
-        tot_snaps = len(dir_frequencies[0])/4
-        
-        #Calculating the average intensity for each freq
-        #Checks the averaging argument, should only be set to True if custom_collect_data is also set to True
-        if averaging == True:
-            avg_633 = ints_633/(tot_snaps*18.02)
-            avg_589 = ints_589/(tot_snaps*18.02)
-            avg_436 = ints_436/(tot_snaps*18.02)
-            avg_355 = ints_355/(tot_snaps*18.02)
-        
-        elif averaging == False:
-            avg_633 = ints_633/(tot_snaps)
-            avg_589 = ints_589/(tot_snaps)
-            avg_436 = ints_436/(tot_snaps)
-            avg_355 = ints_355/(tot_snaps)
-
-        #Assembling all the averages in a list
-        avg_633_list.append(avg_633)
-        avg_589_list.append(avg_589)
-        avg_436_list.append(avg_436)
-        avg_355_list.append(avg_355)
-                
-        #avg_list = [avg_633, avg_589, avg_436, avg_355]
-        #print(avg_list)
-
-    #Printing the number of negative signs for each test
-    print("Number of negative signs: 633nm = ", neg_633, " 589nm = ", neg_589, " 436nm = ", neg_436, " 355nm = ", neg_355)
-
-    return avg_633_list, avg_589_list, avg_436_list, avg_355_list
 
 
 

--- a/SoAPy/functions.py
+++ b/SoAPy/functions.py
@@ -525,17 +525,18 @@ def collect_data(cwd, dir_list, dir_parameters):
                     # Correcting units on incident radiation back to nanometers.
                     frequency = [i / 10 for i in frequency]
 
-                # Appending to test level arrays.
-                test_frequencies.extend(frequency)
-                test_intensities.extend(intensity)
-
                 print(f"Number of Atoms = {natom} \t Number of Basis Functions = {nbf}")
 
                 # Print frequencies and intensities to output file.
                 with open(f"{cwd}/output_data.txt", "a") as file:
                     file.write(f"Snapshot = {conformer_count} \t Number of Atoms = {natom}\n")
-                    for i in range(len(test_frequencies)):
-                        file.write("{:.4f} \t {:e}\n".format(test_frequencies[i], test_intensities[i]))
+                    for i in range(len(frequency)):
+                        file.write("{:.4f} \t {:e}\n".format(frequency[i], intensity[i]))
+                        
+                # Appending to test level arrays.
+                test_frequencies.extend(frequency)
+                test_intensities.extend(intensity)
+
 
             conformer_count += 1
 

--- a/SoAPy/tests/pure_water_inputs/iterative-snaps.py
+++ b/SoAPy/tests/pure_water_inputs/iterative-snaps.py
@@ -1,0 +1,81 @@
+from SoAPy.functions import set_options
+from SoAPy.functions import convert_GROMACS
+from SoAPy.functions import generate_files
+#from SoAPy.functions import generate_coordinates
+from SoAPy.functions import generate_batch_submission_script
+from SoAPy.functions import collect_data
+from SoAPy.functions import custom_collect_data
+from SoAPy.analysis import opt_rot_averaging
+import time
+import os
+import matplotlib.pyplot as plt
+import numpy as np
+
+cwd = os.getcwd()
+
+# Location of MD trajectory.
+#trajectory_location = cwd + '/' + 'SoAPy/SoAPy/tests/B_glucose_test_MD.arc'
+
+# Molecule name
+molecule_name = 'H2O'
+
+# Set testing parameters in lists.
+spectroscopy = ['OptRot']
+shell_type = ['spherical']
+functional = ['CAM-B3LYP']
+basis_set = ['SadleJ pVTZ']
+distance_threshold = ['2.75']
+snapshots = ['1000']
+frequency = ['633nm', '589nm', '436nm', '355nm']
+
+t0 = time.time()
+
+# What type of test is being researched, basis sets, distance thresholds, or number of snapshots?
+dir_list, dir_parameters, relative_dir_list = set_options(spectroscopy, shell_type, functional, basis_set, distance_threshold, snapshots, frequency)
+t1 = time.time()
+
+snaps_633 = []
+snaps_589 = []
+snaps_436 = []
+snaps_355 = []
+collections_of_interest =  [25, 50, 100, 150, 200, 250, 300, 350, 400, 450, 500, 550, 600, 650, 700, 750, 800, 850, 900, 950, 1000]
+#collections_of_interest = np.arange(1, 900, 25, dtype=int)
+for b in range(len(dir_list)):
+    for i in range(len(collections_of_interest)):
+        #starter_cmpd = int(dir_parameters[b][5])//collections_of_interest[i]
+        print("Number of Snapshots to average: ", collections_of_interest[i])
+        #print("Cmpd # we start with/interval: ", starter_cmpd)
+        #cmpd_interval = starter_cmpd
+        
+        #Function to collect data from Gaussian outputs, the cmpd number sampled and interval between cmpds are controllable with the default arguments
+        dir_frequencies, dir_intensities, dir_nbf = custom_collect_data(cwd, dir_list, dir_parameters, conformer = 1, interval = 1, top_out = collections_of_interest[i], averaging = True)
+        t2 = time.time()
+        
+        #Function to average together the optical rotations for each test
+        avg_633_list, avg_589_list, avg_436_list, avg_355_list = opt_rot_averaging(dir_frequencies, dir_intensities, dir_parameters, dir_list, radius = False, averaging = True)
+        snaps_633.append(avg_633_list)
+        snaps_589.append(avg_589_list)
+        snaps_436.append(avg_436_list)
+        snaps_355.append(avg_355_list)
+print(snaps_355)
+#plotting individual lines for each frequency
+#collects = np.ndarray(collections_of_interest)
+plt.plot(collections_of_interest, snaps_633, label= "633")
+plt.plot(collections_of_interest, snaps_589, label= "589")
+plt.plot(collections_of_interest, snaps_436, label= "436")
+plt.plot(collections_of_interest, snaps_355, label= "355")
+
+#Axis labels
+plt.xlabel('Number of Snapshots Averaged')
+plt.ylabel('Average Normalized Optical Rotation')
+
+#Axis bound limits
+#plt.ylim(-4,4)
+
+#Plotting the legend
+plt.legend(loc="upper right")
+
+#Saving the figure with a descriptive title
+plt.savefig(f'/Users/ehfhi/SoAPy/test.pdf')
+
+print("Total Time: ", t2-t0)

--- a/SoAPy/tests/pure_water_inputs/radius-data.py
+++ b/SoAPy/tests/pure_water_inputs/radius-data.py
@@ -1,0 +1,83 @@
+from SoAPy.functions import set_options
+from SoAPy.functions import convert_GROMACS
+from SoAPy.functions import generate_files
+#from SoAPy.functions import generate_coordinates
+from SoAPy.functions import generate_batch_submission_script
+from SoAPy.functions import collect_data
+from SoAPy.functions import custom_collect_data
+from SoAPy.analysis import opt_rot_averaging
+import time
+import os
+import matplotlib.pyplot as plt
+import numpy as np
+
+cwd = os.getcwd()
+
+# Location of MD trajectory.
+#trajectory_location = cwd + '/' + 'SoAPy/SoAPy/tests/B_glucose_test_MD.arc'
+
+# Molecule name
+molecule_name = 'H2O'
+
+# Set testing parameters in lists.
+spectroscopy = ['OptRot']
+shell_type = ['spherical']
+functional = ['CAM-B3LYP']
+basis_set = ['SadleJ pVTZ']
+distance_threshold = ['3', '3.5', '4.5', '5']
+snapshots = ['1']
+frequency = ['633nm', '589nm', '436nm', '355nm']
+
+t0 = time.time()
+
+# What type of test is being researched, basis sets, distance thresholds, or number of snapshots?
+dir_list, dir_parameters, relative_dir_list = set_options(spectroscopy, shell_type, functional, basis_set, distance_threshold, snapshots, frequency)
+t1 = time.time()
+
+#Initializing lists for each spectrum
+snaps_633_spec = []
+snaps_589_spec = []
+snaps_436_spec = []
+snaps_355_spec = []
+
+#The number of snapshots we will average NOT THE TOTAL NUMBER OF SNAPSHOTS THAT WE RAN IN GAUSSIAN
+collections_of_interest =  [1]
+
+
+#Loop over the different numbers of snapshots averaged
+for i in range(len(collections_of_interest)):
+    #Loop over the number of different choices for distance threshold
+        #starter_cmpd = int(dir_parameters[b][5])//collections_of_interest[i]
+        print("Number of Snapshots to average: ", collections_of_interest[i])
+        #print("Cmpd # we start with/interval: ", starter_cmpd)
+        #cmpd_interval = starter_cmpd
+        
+        #Function to collect data from Gaussian outputs, the cmpd number sampled and interval between cmpds are controllable with the default arguments
+        dir_frequencies, dir_intensities, dir_nbf = custom_collect_data(cwd, dir_list, dir_parameters, conformer = 1, interval = 1, top_out = collections_of_interest[i], averaging = True)
+        t2 = time.time()
+        
+        #Function to average together the optical rotations for each test
+        avg_633_list, avg_589_list, avg_436_list, avg_355_list = opt_rot_averaging(dir_frequencies, dir_intensities, dir_parameters, dir_list, radius = True, averaging = True)
+        
+
+
+#plotting individual lines for each frequency
+plt.plot(distance_threshold, avg_633_list, label= "633")
+plt.plot(distance_threshold, avg_589_list, label= "589")
+plt.plot(distance_threshold, avg_436_list, label= "436")
+plt.plot(distance_threshold, avg_355_list, label= "355")
+
+#Axis labels
+plt.xlabel('Solvent Shell Radius (A)')
+plt.ylabel('Average Normalized Optical Rotation')
+
+#Axis bound limits
+#plt.ylim(-4,4)
+
+#Plotting the legend
+plt.legend(loc="upper right")
+
+#Saving the figure with a descriptive title
+plt.savefig(f'/Users/ehfhi/SoAPy/tests-radius-sadlej-100snap.pdf')
+
+print("Total Time: ", t2-t0)


### PR DESCRIPTION
Added opt_rot_averaging function to analysis and created an alternative collect_data function with customization options for radius, optical rotation averaging, and controllable spacing when sampling

## Description
This is a portion of the code I have written to do optical rotation analysis. This is done through the addition of two new functions, custom_collect_data which is the shell of the current collect_data function but with more customization options for different tests and the opt_rot_averaging function which handles the data analysis for optical rotation calculations with respect to either a changing radius or changing number of snapshots. I have also included two example scripts that I use for analysis currently. I plan to add more scripts to the pure_water_inputs folder as we get into production level calculations. These scripts are currently "beta" versions that work properly with the functions in their current form, but both could use further streamlining to fit better into the structure of SoAPy.

I have specifically chosen to only add new functions and not modify anything existing at this time until we have continuous integration testing to ensure that we can test manually if needed.

## Todos
  - The loop structure of the scripts and opt_rot_averaging is functional, but could be significantly more elegant. This will be addressed later.
  - Optical rotation calculations can now be analyzed similarly to ROA/VCD which brings us close to production level work on the pure water project.

## Questions
- Any questions can be addressed on Slack/in-person

## Status
- [ ] Ready to go