### PR TITLE
Module-importing

### DIFF
--- a/SoAPy/__init__.py
+++ b/SoAPy/__init__.py
@@ -1,7 +1,9 @@
 """A package for research on SOlvation Algorithms in PYthon, SoAPy."""
 
 # Add imports here
-from .functions import set_options
+#SoAPy has to import each submodule explicitly in the init for everything to play nicely
+#This 
+from SoAPy import functions, generate_files, analysis, collect_data, get_geometry, collect_data, functions_copy
 
 
 from ._version import __version__

--- a/SoAPy/tests/input_examples/SoAPy_input_from_geom.py
+++ b/SoAPy/tests/input_examples/SoAPy_input_from_geom.py
@@ -1,9 +1,4 @@
-from SoAPy.functions import set_options
-from SoAPy.functions import make_directories
-from SoAPy.functions import generate_files
-from SoAPy.get_geometry import coordinates_from_input
-from SoAPy.functions import generate_batch_submission_script
-
+import SoAPy
 import time
 import os
 
@@ -35,22 +30,22 @@ frequency = []
 t0 = time.time()
 
 # What type of test is being researched, basis sets, distance thresholds, or number of snapshots?
-dir_list, dir_parameters, relative_dir_list = set_options(spectroscopy, shell_type, functional, basis_set, distance_threshold, snapshots, frequency)
+dir_list, dir_parameters, relative_dir_list = SoAPy.functions.set_options(spectroscopy, shell_type, functional, basis_set, distance_threshold, snapshots, frequency)
 t1 = time.time()
 
 # Make the directory structure.
-make_directories(dir_list)
+SoAPy.functions.make_directories(dir_list)
 
 # Generate coordinate data from input geometry.
-dir_data, num_solute_atoms, atom_types = coordinates_from_input(input_geometry, dir_list, dir_parameters)
+dir_data, num_solute_atoms, atom_types = SoAPy.get_geometry.coordinates_from_input(input_geometry, dir_list, dir_parameters)
 t2 = time.time()
 
 # Generate test specific input and SLURM files.
-generate_files(molecule_name, dir_list, dir_parameters, dir_data, num_solute_atoms, atom_types)
+SoAPy.functions.generate_files(molecule_name, dir_list, dir_parameters, dir_data, num_solute_atoms, atom_types)
 t3 = time.time()
 
 # Generate batch submission script.
-generate_batch_submission_script(relative_dir_list, dir_parameters)
+SoAPy.functions.generate_batch_submission_script(relative_dir_list, dir_parameters)
 
 print("Total Time: ", t3-t0)
 


### PR DESCRIPTION
Changed __init__.py to allow for the importing of SoAPy as a single module. This means that functions HAVE to be explicitly called with the SoAPy module call AND the call for their respective submodule.

## Description
Update module importing to let SoAPy be called by scripts through one import statement. Ultimately the same amount of work as before as each function requires a module and submodule call explicitly, but the namespace will be much cleaner. This update makes CI implementation possible.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] Inform other current users of the change to function call syntax
  - [ ] Update scripts with the new syntax (we may want to update the example user scripts regardless for building CI)

## Status
- [x] Ready to go